### PR TITLE
US-RT-002b: Patch crossterm EventStream to use tau-iface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,28 +254,14 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+version = "0.28.0"
 dependencies = [
+ "async-ffi",
  "bitflags",
- "crossterm_winapi",
  "futures-core",
- "mio",
  "parking_lot",
  "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
+ "tau-iface",
 ]
 
 [[package]]
@@ -675,7 +661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1119,27 +1104,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,28 +1370,6 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "process", "io-util
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[patch.crates-io]
+crossterm = { path = "vendor/crossterm" }

--- a/PRD.md
+++ b/PRD.md
@@ -664,7 +664,7 @@ when the host binary (which links `libtau_rt`) loads.
 - [x] `git add -A && git commit -m "feat: tau-rt and tau-iface (US-RT-001, US-RT-002)"`
 - [x] `git push origin master`
 
-### US-RT-002b: Patch crossterm EventStream to use tau-iface [ ]
+### US-RT-002b: Patch crossterm EventStream to use tau-iface [x]
 
 **Description:** Patch vendored crossterm's `EventStream` to use `tau_iface::AsyncFd`
 on stdin instead of the current approach (blocking OS thread + mio sync polling).
@@ -679,17 +679,17 @@ The sync mio-based `poll_internal` / `read_internal` path (used by the blocking
 Only the `event-stream` async path needs patching.
 
 **Acceptance Criteria:**
-- [ ] Vendored crossterm at `vendor/crossterm` (already added as submodule)
-- [ ] Patch `src/event/stream.rs`: replace blocking thread + mio waker approach with
+- [x] Vendored crossterm at `vendor/crossterm` (already added as submodule)
+- [x] Patch `src/event/stream.rs`: replace blocking thread + mio waker approach with
   `tau_iface::AsyncFd` wrapping stdin fd. `poll_next()` awaits readable on the AsyncFd,
   then calls `read_internal()` when data is available.
-- [ ] Remove `mio` and `signal-hook-mio` as dependencies of the `event-stream` feature
+- [x] Remove `mio` and `signal-hook-mio` as dependencies of the `event-stream` feature
   (they remain for the sync `events` feature)
-- [ ] Workspace `[patch.crates-io]` maps crossterm to vendored path
-- [ ] Add `tau-iface` as a dependency of vendored crossterm (behind `event-stream` feature)
-- [ ] `crossterm::event::EventStream` works with tau-rt reactor
-- [ ] `cargo check --workspace` passes
-- [ ] All existing tau-tui tests still pass
+- [x] Workspace `[patch.crates-io]` maps crossterm to vendored path
+- [x] Add `tau-iface` as a dependency of vendored crossterm (behind `event-stream` feature)
+- [x] `crossterm::event::EventStream` works with tau-rt reactor
+- [x] `cargo check --workspace` passes
+- [x] All existing tau-tui tests still pass
 
 ### US-RT-003: Integration test — host and plugin share reactor [ ]
 

--- a/crates/tau-tui/Cargo.toml
+++ b/crates/tau-tui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Terminal UI library with differential rendering for tau"
 
 [dependencies]
-crossterm = { version = "0.28", features = ["event-stream"] }
+crossterm = { version = "0.28", default-features = false, features = ["event-stream", "bracketed-paste"] }
 unicode-width = "0.2"
 unicode-segmentation = "1.11"
 tokio.workspace = true

--- a/progress.txt
+++ b/progress.txt
@@ -443,3 +443,32 @@ Fix inserted as US-012a: Input scroll and padding must operate consistently in c
   - `cargo test -p tau-iface` requires `LIBRARY_PATH=target/debug` to find libtau_rt.dylib at link time
 ## Task self-review PASSED
 ---
+
+## Iteration 1 - US-RT-002b: Patch crossterm EventStream to use tau-iface
+- What was done: Patched vendored crossterm's EventStream to use tau_iface::AsyncFd instead of blocking thread + mio waker. Rewrote stream.rs completely. Updated feature gates across 6 crossterm source files. Added workspace [patch.crates-io] for crossterm. Set tau-tui to use default-features=false.
+- Files changed:
+  - Cargo.toml (workspace patch)
+  - Cargo.lock (updated crossterm resolution)
+  - crates/tau-tui/Cargo.toml (default-features=false, event-stream+bracketed-paste)
+  - vendor/crossterm/Cargo.toml (tau-iface, async-ffi as optional deps; event-stream decoupled from events)
+  - vendor/crossterm/src/lib.rs (event module gate: any(events, event-stream))
+  - vendor/crossterm/src/event.rs (gate filter/read/source/timeout/poll/read behind events)
+  - vendor/crossterm/src/event/stream.rs (complete rewrite: AsyncFd + self-pipe SIGWINCH + inline Parser)
+  - vendor/crossterm/src/event/sys.rs (Waker re-export needs both events+event-stream)
+  - vendor/crossterm/src/event/sys/unix.rs (parse: any(events, event-stream); waker: both)
+  - PRD.md (acceptance criteria marked [x])
+- Learnings for future iterations:
+  - crossterm's `default` features include `events` which pulls in mio — must use `default-features = false` when only `event-stream` is needed
+  - The `event` module in crossterm's lib.rs was gated behind `events` only — needed `any(events, event-stream)` to make EventStream accessible without sync polling
+  - Feature decoupling required careful analysis: `read.rs`, `source.rs`, `filter.rs`, `timeout.rs` all depend on mio-based EventSource and must be gated behind `events`
+  - `parse_event` (in sys/unix/parse.rs) is the only shared code between events and event-stream — all other internal modules are events-only
+  - AsyncFd in tau-iface does NOT own the fd — caller must close fds manually (important for pipe read-end in Drop)
+  - Drop body runs BEFORE struct field destructors — reactor's io_deregister ignores EBADF so closing pipe fd before AsyncFd drops is safe
+  - Raw FFI declarations for pipe/signal/fcntl avoid pulling in libc crate (crossterm defaults to rustix)
+  - SIGWINCH self-pipe pattern: signal handler writes 1 byte, pipe read-end registered with reactor, poll_next checks both stdin and sigwinch fds
+  - `async_ffi::ContextExt::with_ffi_context` bridges std::task::Context to FfiContext for calling tau-rt FFI from within poll_next
+  - Global AtomicI32 for pipe write-end fd — acceptable since crossterm only supports one event reader at a time (global INTERNAL_EVENT_READER)
+  - The Parser is duplicated from source/unix/mio.rs (~50 lines) rather than extracted to shared module — keeps event-stream independent of events feature
+  - `cargo test -p tau-tui` requires `LIBRARY_PATH=target/debug` to find libtau_rt.dylib at link time
+## Task self-review PASSED
+---


### PR DESCRIPTION
Closes #3

## Summary

Patches the vendored crossterm's `EventStream` to use `tau_iface::AsyncFd` on stdin instead of the blocking OS thread + mio waker approach.

## Changes

### vendor/crossterm (submodule)
- **stream.rs**: Complete rewrite — uses `AsyncFd` on stdin fd for readability polling through the tau-rt reactor. SIGWINCH detected via a self-pipe whose read-end is also registered with the reactor. Inline `Parser` for byte→event parsing (copy from `source/unix/mio.rs`).
- **Cargo.toml**: `event-stream` feature decoupled from `events` — depends on `tau-iface`, `async-ffi`, `futures-core` only (no mio, no signal-hook-mio).
- **Feature gates**: `parse_event` available for both `events` and `event-stream`. Sync-only modules (`filter`, `read`, `source`, `timeout`) gated behind `events`. Waker module requires both features.
- **lib.rs**: Event module gate changed to `any(events, event-stream)`.

### Workspace
- `Cargo.toml`: Added `[patch.crates-io]` mapping crossterm to vendored path.
- `crates/tau-tui/Cargo.toml`: `default-features = false` with `event-stream` + `bracketed-paste` — avoids pulling mio via default feature's `events`.

## Testing
- `cargo check --workspace` passes
- All 258 tau-tui tests pass
- crossterm dependency tree shows no mio/signal-hook (only from tokio which is a separate dep)